### PR TITLE
`Fix`: User Intent Create sends `auth` using client and secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
+Updates are from recent to latest (most recent is immediately below) 
+
 ## 1.0.0-alpha.11 ~ 2022-10-03
+
+### Major Change
+- `AuthResource` has `basicAuth` getter for setting the Basic Auth Credentials on some of the resource requests.
+- User and Intent resources now receive Auth resource
 
 ### Fixed
 - Astra User Intent Create sends `auth` using client and secret. Previously, this caused `POST` `user_intent` to fail with Authorization error. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.0-alpha.11 ~ 2022-10-03
+
+### Fixed
+- Astra User Intent Create sends `auth` using client and secret. Previously, this caused `POST` `user_intent` to fail with Authorization error. 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
-  "version": "1.0.0-alpha.10",
+  "version": "1.0.0-alpha.11",
   "description": "Astra Finance JS SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/astra.ts
+++ b/src/client/astra.ts
@@ -99,7 +99,7 @@ export class Astra {
 
   protected _initResources() {
     this.auth = new AuthResource(this._client, this._clientId, this._clientSecret)
-    this.users = new Users(this._client)
+    this.users = new Users(this._client, this.auth)
     this.routines = new RoutinesResource(this._client, this.auth)
     this.cards = new CardsResource(this._client, this.auth)
     this.transfers = new TransfersResource(this._client, this.auth)

--- a/src/resources/auth/index.ts
+++ b/src/resources/auth/index.ts
@@ -1,4 +1,4 @@
-import { Axios } from 'axios'
+import { Axios, AxiosBasicCredentials } from 'axios'
 import { AstraResponse } from '../../lib/AstraResponse'
 import { AstraResponseError } from '../../lib/AstraResponseError'
 
@@ -30,6 +30,13 @@ export class AuthResource {
     this._clientSecret = clientSecret
   }
 
+  get basicAuth(): AxiosBasicCredentials {
+    return {
+      username: this._clientId,
+      password: this._clientSecret,
+    }
+  }
+
   async createAccessToken(request: AstraCreateAccessTokenRequest): Promise<AstraResponse<AstraAccessTokenResponse>> {
     const headers: { [key: string]: string } = {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -40,10 +47,7 @@ export class AuthResource {
       `grant_type=authorization_code&code=${request.code}&redirect_uri=${request.redirect_uri}`,
       {
         headers,
-        auth: {
-          username: this._clientId,
-          password: this._clientSecret,
-        },
+        auth: this.basicAuth,
       }
     )
 

--- a/src/resources/users/index.ts
+++ b/src/resources/users/index.ts
@@ -1,12 +1,12 @@
 import { Axios } from 'axios'
 import { Intents } from './intents'
+import { AuthResource } from '../auth'
 
 export class Users {
-  private _client: Axios
-
   intents: Intents
-  constructor(client: Axios) {
-    this._client = client
-    this.intents = new Intents(this._client)
+  auth: AuthResource
+
+  constructor(client: Axios, auth: AuthResource) {
+    this.intents = new Intents(client, this.auth)
   }
 }

--- a/src/resources/users/intents.test.ts
+++ b/src/resources/users/intents.test.ts
@@ -7,7 +7,7 @@ describe('Users > intents', () => {
 
   describe('create', () => {
     it('throws if a required request parameter is missing', async () => {
-      const intents = new Intents(mockAxios)
+      const intents = new Intents(mockAxios, '1', '2')
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const create = () => intents.create({ email: 'test@test.com' } as any)
       await expect(create()).rejects.toThrowError(

--- a/src/resources/users/intents.test.ts
+++ b/src/resources/users/intents.test.ts
@@ -1,5 +1,6 @@
 import { Intents } from './intents'
 import axios from 'axios'
+import { AuthResource } from '../auth'
 
 describe('Users > intents', () => {
   jest.mock('axios')
@@ -7,7 +8,7 @@ describe('Users > intents', () => {
 
   describe('create', () => {
     it('throws if a required request parameter is missing', async () => {
-      const intents = new Intents(mockAxios, '1', '2')
+      const intents = new Intents(mockAxios, new AuthResource(mockAxios, '1', '2'))
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const create = () => intents.create({ email: 'test@test.com' } as any)
       await expect(create()).rejects.toThrowError(

--- a/src/resources/users/intents.ts
+++ b/src/resources/users/intents.ts
@@ -3,6 +3,7 @@ import { omit } from 'lodash'
 import transformRequest from '../../lib/utils/transformRequest'
 import { AstraResponse } from '../../lib/AstraResponse'
 import createUserIntentValidator from './validators/createUserIntentValidator'
+import { AuthResource } from '../auth'
 
 export interface UserIntentRequest {
   email: string
@@ -29,13 +30,11 @@ export interface CreateUserIntentResponse {
 export class Intents {
   protected _path = 'v1/user_intent'
   protected _client: Axios
-  protected _clientId: string
-  protected _clientSecret: string
+  protected _authResource: AuthResource
 
-  constructor(client: Axios, clientId: string, clientSecret: string) {
+  constructor(client: Axios, auth: AuthResource) {
     this._client = client
-    this._clientId = clientId
-    this._clientSecret = clientSecret
+    this._authResource = auth
   }
 
   async create(request: UserIntentRequest): Promise<AstraResponse<CreateUserIntentResponse>> {
@@ -57,10 +56,7 @@ export class Intents {
         AxiosResponse<CreateUserIntentResponse>,
         UserIntentRequest
       >(this._path, transformedRequest, {
-        auth: {
-          username: this._clientId,
-          password: this._clientSecret,
-        },
+        auth: this._authResource.basicAuth,
       })
 
       if (axios.isAxiosError(data)) {


### PR DESCRIPTION

### Major Change
- `AuthResource` has `basicAuth` getter for setting the Basic Auth Credentials on some of the resource requests.
- User and Intent resources now receive Auth resource

### Fixed
- Astra User Intent Create sends `auth` using client and secret. Previously, this caused `POST` `user_intent` to fail with Authorization error. 