### PR TITLE
Fix/user intent create

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,6 @@ module.exports = {
   ignorePatterns: ['/dist/**/*'],
   rules: {
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': 'off', /// There is a bug with eslint that I cannot resolve
+    '@typescript-eslint/no-unused-vars': 2,
   },
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Updates are from recent to latest (most recent is immediately below) 
 
+## 1.0.0-alpha.12 ~ 2022-10-03
+
+### Fixed
+- `users.intents.create()` actually sends Basic Auth. _We now lint for unused vars and created a test that would have caught the bug too._
+
 ## 1.0.0-alpha.11 ~ 2022-10-03
 
 ### Major Change

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "description": "Astra Finance JS SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/astra.ts
+++ b/src/client/astra.ts
@@ -124,6 +124,6 @@ export class Astra {
    *
    * @protected
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-function
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
   protected _attachLoggers(request: AxiosInterceptorManager<any>, response: AxiosInterceptorManager<any>) {}
 }

--- a/src/resources/users/index.ts
+++ b/src/resources/users/index.ts
@@ -7,6 +7,6 @@ export class Users {
   auth: AuthResource
 
   constructor(client: Axios, auth: AuthResource) {
-    this.intents = new Intents(client, this.auth)
+    this.intents = new Intents(client, auth)
   }
 }

--- a/src/resources/users/intents.test.ts
+++ b/src/resources/users/intents.test.ts
@@ -1,10 +1,24 @@
 import { Intents } from './intents'
-import axios from 'axios'
 import { AuthResource } from '../auth'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { Astra, BaseURL } from '../../client/astra'
 
 describe('Users > intents', () => {
-  jest.mock('axios')
-  const mockAxios = axios as jest.Mocked<typeof axios>
+  let mockAxios
+  let astraClient
+  beforeAll(() => {
+    mockAxios = new MockAdapter(axios)
+    astraClient = new Astra({
+      clientId: '1',
+      clientSecret: '2',
+      baseUrl: BaseURL.Sandbox,
+    })
+  })
+
+  afterEach(() => {
+    mockAxios.reset()
+  })
 
   describe('create', () => {
     it('throws if a required request parameter is missing', async () => {
@@ -14,6 +28,41 @@ describe('Users > intents', () => {
       await expect(create()).rejects.toThrowError(
         "data must have required property 'phone', data must have required property 'firstName', data must have required property 'lastName', data must have required property 'address1', data must have required property 'city', data must have required property 'state', data must have required property 'postalCode', data must have required property 'dateOfBirth', data must have required property 'ssn', data must have required property 'ipAddress'"
       )
+    })
+    it('should successfully return create', async () => {
+      // given
+      const data = {
+        id: '12323',
+      }
+      mockAxios.onPost(`${BaseURL.Sandbox}/v1/user_intent`).reply(201, JSON.stringify(data))
+
+      // when
+      const result = await astraClient.users.intents.create({
+        email: 'sir.edmund.hillary@gmail.com',
+        phone: '+15557771234',
+        firstName: 'Edmund',
+        lastName: 'Hillary',
+        preferredFirstName: 'Ed',
+        preferredLastName: 'Hill',
+        preferredPronouns: 'He/Him',
+        address1: '123 Astra Ave',
+        address2: 'Apt 456',
+        city: 'Palo Alto',
+        state: 'CA',
+        postalCode: '94304',
+        dateOfBirth: '1919-07-20',
+        ssn: '9999',
+        ipAddress: 'your_ip_address',
+      })
+
+      // then
+      expect(result).toEqual(data)
+      const request = mockAxios.history.post[0]
+      expect(request.url).toEqual(`v1/user_intent`)
+      expect(request.auth).toEqual({
+        username: '1',
+        password: '2',
+      })
     })
   })
 })


### PR DESCRIPTION
## Fixed
`users.intents.create()` actually sends Basic Auth. _We now lint for unused vars and created a test that would have caught the bug too._